### PR TITLE
style(prettier): ports prettier config from official gatsby repo

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+  endOfLine: "lf",
+  semi: false,
+  singleQuote: false,
+  tabWidth: 2,
+  trailingComma: "es5",
+}


### PR DESCRIPTION
ports: https://github.com/gatsbyjs/gatsby/blob/master/.prettierrc.js 

without this and if you had format on save enabled in your IDE, prettier would remove trailing commas, add semis, and change quotes (probably depends on your original config also -- happened to me)

