### PR TITLE
Remove remaining relative imports

### DIFF
--- a/docs/contributing/index.mdx
+++ b/docs/contributing/index.mdx
@@ -3,8 +3,6 @@ title: Contributing to Gatsby.js
 disableTableOfContents: true
 ---
 
-import EmailCaptureForm from "../../www/src/components/email-capture-form"
-
 Thanks for being interested in contributing! We're so glad you want to help!
 
 Below you'll find guides on the Gatsby.js community, code of conduct, and how to get started contributing:

--- a/docs/docs/data-fetching.md
+++ b/docs/docs/data-fetching.md
@@ -2,9 +2,6 @@
 title: Build Time and Client Runtime Data Fetching
 ---
 
-import BuildDataExample from "../../www/src/components/build-data-example.js"
-import ClientDataExample from "../../www/src/components/client-data-example.js"
-
 This guide demonstrates how to fetch data at both [_build time_](/docs/glossary#build) and [_runtime_](/docs/glossary#runtime) in Gatsby. Most of the techniques outlined are for custom data handling. Be sure to check out Gatsby's [plugin library](/plugins/) to see if there's an off-the-shelf solution for your data requirements, such as [sourcing from a CMS](/docs/headless-cms/) or other third-party integration.
 
 ## The benefits of the hybrid nature of Gatsby apps

--- a/docs/docs/graphql-api.md
+++ b/docs/docs/graphql-api.md
@@ -3,9 +3,6 @@ title: GraphQL API
 tableOfContentsDepth: 2
 ---
 
-import { GraphqlApiQuery } from "../../www/src/components/api-reference/doc-static-queries"
-import APIReference from "../../www/src/components/api-reference"
-
 A great advantage of Gatsby is a built-in data layer that combines all data sources you configure. Data is collected at [build time](/docs/glossary#build) and automatically assembled into a [schema](/docs/glossary#schema) that defines how data can be queried throughout your site.
 
 This doc serves as a reference for GraphQL features built into Gatsby, including methods for querying and sourcing data, and customizing GraphQL for your site's needs.
@@ -237,27 +234,9 @@ The following fragments are available in any site with `gatsby-transformer-sharp
 
 Information on querying with these fragments is also listed in-depth in the [Gatsby image API docs](/docs/gatsby-image/), including options like resizing and recoloring.
 
-<GraphqlApiQuery>
-  {data => (
-    <APIReference
-      relativeFilePath={data.transformerSharp.nodes[0].relativePath}
-      docs={data.transformerSharp.nodes[0].childrenDocumentationJs}
-    />
-  )}
-</GraphqlApiQuery>
-
 #### Contentful fragments
 
 The following fragments are available in any site with `gatsby-source-contentful` installed and included in your `gatsby-config.js`. These fragments generally mirror the fragments outlined in the `gatsby-transformer-sharp` package.
-
-<GraphqlApiQuery>
-  {data => (
-    <APIReference
-      relativeFilePath={data.contentfulFragments.nodes[0].relativePath}
-      docs={data.contentfulFragments.nodes[0].childrenDocumentationJs}
-    />
-  )}
-</GraphqlApiQuery>
 
 **Note**: the above fragments are from officially maintained Gatsby starters; other plugins like `gatsby-source-datocms` and `gatsby-source-sanity` ship with fragments of their own. A list of those fragments can be found in the [`gatsby-image` README](/packages/gatsby-image#fragments).
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -3,8 +3,6 @@ title: Gatsby.js Documentation
 disableTableOfContents: true
 ---
 
-import EmailCaptureForm from "../../www/src/components/email-capture-form"
-
 Gatsby is a blazing fast modern site generator for React.
 
 ## Get Started


### PR DESCRIPTION
After #29 , a couple of pages still contained relative imports, which caused the build to break when sourced from a translation repo: gatsbyjs/gatsby#19036

Remove remaining relative imports to allow being used through `gatsby-source-git`.
This way, local development of gatsbyjs/gatsby works again with the `LOCALES` env variable set.
